### PR TITLE
Update import

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ammonite: 2.X
 Edit `~/.ammonite/predef.sc`
 
 ```
-interp.load.ivy("com.github.chengpohi" %% "ammonite-vi" % "2.0")
+import $ivy.`com.github.chengpohi:ammonite-vi_2.13:2.0`
 
 @
 


### PR DESCRIPTION
The example predef didn't work for me because the dependency wasn't named correctly. 

As it can be seen in the link below it should be `ammonite-vi_2.13` instead of just `ammonite-vi`:
https://repo1.maven.org/maven2/com/github/chengpohi/ammonite-vi_2.13/